### PR TITLE
Using Krylov linear solver to accelerate environment update

### DIFF
--- a/examples/vumps/vumps_heisenberg.jl
+++ b/examples/vumps/vumps_heisenberg.jl
@@ -1,7 +1,20 @@
 using ITensors
 using ITensorInfiniteMPS
 
-N = 2
+##############################################################################
+# VUMPS parameters
+#
+
+maxdim = 30 # Maximum bond dimension
+cutoff = 1e-6 # Singular value cutoff when increasing the bond dimension
+max_vumps_iters = 100 # Maximum number of iterations of the VUMPS algorithm at each bond dimension
+outer_iters = 6 # Number of times to increase the bond dimension
+
+##############################################################################
+# CODE BELOW HERE DOES NOT NEED TO BE MODIFIED
+#
+
+N = 2 # Number of sites in the unit cell
 
 heisenberg_space_shift(q̃nf, q̃sz) = [QN("Sz", 1 - q̃sz) => 1, QN("Sz", -1 - q̃sz) => 1]
 
@@ -18,11 +31,7 @@ H = InfiniteITensorSum(model, s)
 # Check translational invariance
 @show norm(contract(ψ.AL[1:N]..., ψ.C[N]) - contract(ψ.C[0], ψ.AR[1:N]...))
 
-cutoff = 1e-8
-maxdim = 20
-maxiter = 100
-outer_iters = 5
-vumps_kwargs = (tol=1e-8, maxiter=maxiter)
+vumps_kwargs = (tol=1e-8, maxiter=max_vumps_iters)
 subspace_expansion_kwargs = (cutoff=cutoff, maxdim=maxdim)
 ψ = vumps(H, ψ; vumps_kwargs...)
 

--- a/examples/vumps/vumps_heisenberg.jl
+++ b/examples/vumps/vumps_heisenberg.jl
@@ -1,15 +1,12 @@
 using ITensors
 using ITensorInfiniteMPS
 
-include("models.jl")
-include("infinitecanonicalmps.jl")
-
 N = 2
 
 heisenberg_space_shift(q̃nf, q̃sz) = [QN("Sz", 1 - q̃sz) => 1, QN("Sz", -1 - q̃sz) => 1]
 
-electron_space = fill(electron_space_shift(1, 0), N)
-s = infsiteinds("Electron", N; space=electron_space)
+heisenberg_space = fill(heisenberg_space_shift(1, 0), N)
+s = infsiteinds("S=1/2", N; space=heisenberg_space)
 initstate(n) = isodd(n) ? "↑" : "↓"
 ψ = InfMPS(s, initstate)
 
@@ -23,15 +20,40 @@ H = InfiniteITensorSum(model, s)
 
 cutoff = 1e-8
 maxdim = 100
-environment_iterations = 20
-niter = 20
+environment_iterations = 300
+niter = 200
+outer_iters = 6
 vumps_kwargs = (environment_iterations=environment_iterations, niter=niter)
-ψ = subspace_expansion(ψ, H; cutoff=cutoff, maxdim=maxdim)
+subspace_expansion_kwargs = (cutoff=cutoff, maxdim=maxdim)
+
+println("\nRun VUMPS on initial product state, unit cell size $N")
 ψ = vumps(H, ψ; vumps_kwargs...)
-ψ = subspace_expansion(ψ, H; cutoff=cutoff, maxdim=maxdim)
-ψ = vumps(H, ψ; vumps_kwargs...)
-ψ = subspace_expansion(ψ, H; cutoff=cutoff, maxdim=maxdim)
-ψ = vumps(H, ψ; vumps_kwargs...)
+
+for _ in 1:outer_iters
+  println("\nIncrease bond dimension")
+  global ψ = subspace_expansion(ψ, H; subspace_expansion_kwargs...)
+  println("Run VUMPS with new bond dimension")
+  global ψ = vumps(H, ψ; vumps_kwargs...)
+end
 
 # Check translational invariance
 @show norm(contract(ψ.AL[1:N]..., ψ.C[N]) - contract(ψ.C[0], ψ.AR[1:N]...))
+
+function ITensors.expect(ψ::InfiniteCanonicalMPS, o, n)
+  return (noprime(ψ.AL[n] * ψ.C[n] * op(o, s[n])) * dag(ψ.AL[n] * ψ.C[n]))[]
+end
+
+function expect_two_site(ψ::InfiniteCanonicalMPS, h::ITensor, n1n2)
+  n1, n2 = n1n2
+  ϕ = ψ.AL[n1] * ψ.AL[n2] * ψ.C[n2]
+  return (noprime(ϕ * h) * dag(ϕ))[]
+end
+
+Sz = [expect(ψ, "Sz", n) for n in 1:N]
+
+bs = [(1, 2), (2, 3)]
+energy_infinite = map(b -> expect_two_site(ψ, H[b], b), bs)
+
+@show energy_infinite
+@show Sz
+

--- a/examples/vumps/vumps_heisenberg.jl
+++ b/examples/vumps/vumps_heisenberg.jl
@@ -90,4 +90,3 @@ orthogonalize!(ψfinite, nfinite + 1)
 Sz2_finite = expect(ψfinite[nfinite + 1], "Sz")
 
 @show Sz1_finite, Sz2_finite
-

--- a/examples/vumps/vumps_heisenberg.jl
+++ b/examples/vumps/vumps_heisenberg.jl
@@ -10,7 +10,7 @@ s = infsiteinds("S=1/2", N; space=heisenberg_space)
 initstate(n) = isodd(n) ? "↑" : "↓"
 ψ = InfMPS(s, initstate)
 
-model = Model(:heisenberg)
+model = Model"heisenberg"()
 
 # Form the Hamiltonian
 H = InfiniteITensorSum(model, s)
@@ -19,16 +19,14 @@ H = InfiniteITensorSum(model, s)
 @show norm(contract(ψ.AL[1:N]..., ψ.C[N]) - contract(ψ.C[0], ψ.AR[1:N]...))
 
 cutoff = 1e-8
-maxdim = 100
-environment_iterations = 300
-niter = 200
-outer_iters = 6
-vumps_kwargs = (environment_iterations=environment_iterations, niter=niter)
+maxdim = 20
+maxiter = 100
+outer_iters = 5
+vumps_kwargs = (tol=1e-8, maxiter=maxiter)
 subspace_expansion_kwargs = (cutoff=cutoff, maxdim=maxdim)
-
-println("\nRun VUMPS on initial product state, unit cell size $N")
 ψ = vumps(H, ψ; vumps_kwargs...)
 
+# Alternate steps of running VUMPS and increasing the bond dimension
 for _ in 1:outer_iters
   println("\nIncrease bond dimension")
   global ψ = subspace_expansion(ψ, H; subspace_expansion_kwargs...)
@@ -56,4 +54,31 @@ energy_infinite = map(b -> expect_two_site(ψ, H[b], b), bs)
 
 @show energy_infinite
 @show Sz
+
+#
+# Compare to DMRG
+#
+
+Nfinite = 50
+sfinite = siteinds("S=1/2", Nfinite; conserve_szparity=true)
+Hfinite = MPO(model, sfinite)
+ψfinite = randomMPS(sfinite, initstate)
+@show flux(ψfinite)
+sweeps = Sweeps(15)
+setmaxdim!(sweeps, maxdim)
+setcutoff!(sweeps, cutoff)
+energy_finite_total, ψfinite = dmrg(Hfinite, ψfinite, sweeps)
+@show energy_finite_total / Nfinite
+
+function ITensors.expect(ψ, o)
+  return (noprime(ψ * op(o, filterinds(ψ, "Site")...)) * dag(ψ))[]
+end
+
+nfinite = Nfinite ÷ 2
+orthogonalize!(ψfinite, nfinite)
+Sz1_finite = expect(ψfinite[nfinite], "Sz")
+orthogonalize!(ψfinite, nfinite + 1)
+Sz2_finite = expect(ψfinite[nfinite + 1], "Sz")
+
+@show Sz1_finite, Sz2_finite
 

--- a/examples/vumps/vumps_hubbard_extended.jl
+++ b/examples/vumps/vumps_hubbard_extended.jl
@@ -19,7 +19,7 @@ initstate(n) = isodd(n) ? "↑" : "↓"
 ψ = InfMPS(s, initstate)
 
 model = Model"hubbard"()
-model_params = (t=1.0, U=8.0, V=0.0)
+model_params = (t=1.0, U=0.0, V=0.0)
 @show model, model_params
 
 # Form the Hamiltonian
@@ -32,8 +32,8 @@ println("\nCheck translational invariance of initial infinite MPS")
 cutoff = 1e-8
 maxdim = 100
 outputlevel = 1
-environment_iterations = 30 # Number of iterations used to sum up the Hamiltonian terms (summing a geometric series with a recursive formula, one term at a time)
-vumps_iters = 30 # Number of VUMPS iterations at a given bond dimension
+environment_iterations = 100 # Number of iterations used to sum up the Hamiltonian terms (summing a geometric series with a recursive formula, one term at a time)
+vumps_iters = 100 # Number of VUMPS iterations at a given bond dimension
 outer_iters = 3 # Number of times to increase the bond dimension then run vumps_iters VUMPS iterations
 vumps_kwargs = (
   environment_iterations=environment_iterations, niter=vumps_iters, outputlevel=outputlevel
@@ -93,8 +93,8 @@ Hfinite = MPO(model, sfinite; model_params...)
 ψfinite = randomMPS(sfinite, initstate; linkdims=10)
 println("\nQN sector of starting finite MPS")
 @show flux(ψfinite)
-sweeps = Sweeps(20)
-setmaxdim!(sweeps, 40)
+sweeps = Sweeps(30)
+setmaxdim!(sweeps, 2, 2, 2, 2, 4, 4, 4, 4, 8, 8, 8, 8, 16, 16, 16, 16, 32, 32, 32, 32, 50)
 setcutoff!(sweeps, 1E-8)
 println("\nRun DMRG on $Nfinite sites")
 energy_finite_total, ψfinite = dmrg(Hfinite, ψfinite, sweeps)

--- a/examples/vumps/vumps_hubbard_extended.jl
+++ b/examples/vumps/vumps_hubbard_extended.jl
@@ -43,9 +43,7 @@ println("\nCheck translational invariance of initial infinite MPS")
 @show norm(contract(ψ.AL[1:N]..., ψ.C[N]) - contract(ψ.C[0], ψ.AR[1:N]...))
 
 outputlevel = 1
-vumps_kwargs = (
-  tol=1e-8, maxiter=max_vumps_iters, outputlevel=outputlevel
-)
+vumps_kwargs = (tol=1e-8, maxiter=max_vumps_iters, outputlevel=outputlevel)
 subspace_expansion_kwargs = (cutoff=cutoff, maxdim=maxdim)
 
 # For now, to increase the bond dimension you must alternate
@@ -102,7 +100,8 @@ Hfinite = MPO(model, sfinite; model_params...)
 println("\nQN sector of starting finite MPS")
 @show flux(ψfinite)
 sweeps = Sweeps(30)
-maxdims = min.(maxdim, [2, 2, 2, 2, 4, 4, 4, 4, 8, 8, 8, 8, 16, 16, 16, 16, 32, 32, 32, 32, 50])
+maxdims =
+  min.(maxdim, [2, 2, 2, 2, 4, 4, 4, 4, 8, 8, 8, 8, 16, 16, 16, 16, 32, 32, 32, 32, 50])
 @show maxdims
 setmaxdim!(sweeps, maxdims...)
 setcutoff!(sweeps, cutoff)

--- a/examples/vumps/vumps_hubbard_extended.jl
+++ b/examples/vumps/vumps_hubbard_extended.jl
@@ -19,7 +19,7 @@ initstate(n) = isodd(n) ? "↑" : "↓"
 ψ = InfMPS(s, initstate)
 
 model = Model"hubbard"()
-model_params = (t=1.0, U=12.0, V=0.0)
+model_params = (t=1.0, U=0.0, V=0.0)
 @show model, model_params
 
 # Form the Hamiltonian
@@ -32,11 +32,11 @@ println("\nCheck translational invariance of initial infinite MPS")
 cutoff = 1e-8
 maxdim = 10
 outputlevel = 1
-environment_iterations = 100 # Number of iterations used to sum up the Hamiltonian terms (summing a geometric series with a recursive formula, one term at a time)
-vumps_iters = 100 # Number of VUMPS iterations at a given bond dimension
-outer_iters = 4 # Number of times to increase the bond dimension then run vumps_iters VUMPS iterations
+tol = 1e-8
+vumps_iters = 200 # Number of VUMPS iterations at a given bond dimension
+outer_iters = 5 # Number of times to increase the bond dimension then run vumps_iters VUMPS iterations
 vumps_kwargs = (
-  environment_iterations=environment_iterations, niter=vumps_iters, outputlevel=outputlevel
+  tol=tol, maxiter=vumps_iters, outputlevel=outputlevel
 )
 subspace_expansion_kwargs = (cutoff=cutoff, maxdim=maxdim)
 

--- a/examples/vumps/vumps_hubbard_extended.jl
+++ b/examples/vumps/vumps_hubbard_extended.jl
@@ -19,7 +19,7 @@ initstate(n) = isodd(n) ? "↑" : "↓"
 ψ = InfMPS(s, initstate)
 
 model = Model"hubbard"()
-model_params = (t=1.0, U=0.0, V=0.0)
+model_params = (t=1.0, U=12.0, V=0.0)
 @show model, model_params
 
 # Form the Hamiltonian
@@ -30,11 +30,11 @@ println("\nCheck translational invariance of initial infinite MPS")
 @show norm(contract(ψ.AL[1:N]..., ψ.C[N]) - contract(ψ.C[0], ψ.AR[1:N]...))
 
 cutoff = 1e-8
-maxdim = 100
+maxdim = 10
 outputlevel = 1
 environment_iterations = 100 # Number of iterations used to sum up the Hamiltonian terms (summing a geometric series with a recursive formula, one term at a time)
 vumps_iters = 100 # Number of VUMPS iterations at a given bond dimension
-outer_iters = 3 # Number of times to increase the bond dimension then run vumps_iters VUMPS iterations
+outer_iters = 4 # Number of times to increase the bond dimension then run vumps_iters VUMPS iterations
 vumps_kwargs = (
   environment_iterations=environment_iterations, niter=vumps_iters, outputlevel=outputlevel
 )

--- a/examples/vumps/vumps_ising.jl
+++ b/examples/vumps/vumps_ising.jl
@@ -1,10 +1,25 @@
 using ITensorInfiniteMPS
 using ITensorInfiniteMPS.ITensors
 
-N = 2
+##############################################################################
+# VUMPS parameters
+#
+
+maxdim = 30 # Maximum bond dimension
+cutoff = 1e-8 # Singular value cutoff when increasing the bond dimension
+max_vumps_iters = 100 # Maximum number of iterations of the VUMPS algorithm at a fixed bond dimension
+outer_iters = 5 # Number of times to increase the bond dimension
+
+# Parameters of the transverse field Ising model
+model_kwargs = (J=1.0, h=1.0)
+
+##############################################################################
+# CODE BELOW HERE DOES NOT NEED TO BE MODIFIED
+#
+
+N = 2 # Number of sites in the unit cell
 
 model = Model"ising"()
-model_kwargs = (J=1.0, h=1.0)
 
 function space_shifted(::Model"ising", q̃sz)
   return [QN("SzParity", 1 - q̃sz, 2) => 1, QN("SzParity", 0 - q̃sz, 2) => 1]
@@ -21,11 +36,7 @@ H = InfiniteITensorSum(model, s; model_kwargs...)
 # Check translational invariance
 @show norm(contract(ψ.AL[1:N]..., ψ.C[N]) - contract(ψ.C[0], ψ.AR[1:N]...))
 
-cutoff = 1e-8
-maxdim = 20
-maxiter = 100
-outer_iters = 5
-vumps_kwargs = (tol=1e-8, maxiter=maxiter)
+vumps_kwargs = (tol=1e-8, maxiter=max_vumps_iters)
 subspace_expansion_kwargs = (cutoff=cutoff, maxdim=maxdim)
 ψ = vumps(H, ψ; vumps_kwargs...)
 

--- a/examples/vumps/vumps_ising.jl
+++ b/examples/vumps/vumps_ising.jl
@@ -83,7 +83,7 @@ Sz2_infinite = expect(ψ.AL[2] * ψ.C[2], "Sz")
 ###################################################################
 # Test using linsolve to compute environment
 
-function test_left_environment(∑h::InfiniteITensorSum, ψ::InfiniteCanonicalMPS)
+function test_left_environment(∑h::InfiniteITensorSum, ψ::InfiniteCanonicalMPS; niter)
   Nsites = nsites(ψ)
   ψᴴ = dag(ψ)
   ψ′ = ψᴴ'
@@ -127,8 +127,10 @@ function test_left_environment(∑h::InfiniteITensorSum, ψ::InfiniteCanonicalMP
     hᴿ[n] -= eᴿ[n] * denseblocks(δ(inds(hᴿ[n])))
   end
 
-  return hᴸ
+  Hᴸ_rec = ITensorInfiniteMPS.left_environment_recursive(hᴸ, ψ; niter=niter)
+  Hᴸ = ITensorInfiniteMPS.left_environment(hᴸ, ψ)
+  return Hᴸ, Hᴸ_rec
 end
 
-r = test_left_environment(H, ψ)
+Hᴸ, Hᴸ_rec = test_left_environment(H, ψ; niter=40)
 

--- a/examples/vumps/vumps_ising.jl
+++ b/examples/vumps/vumps_ising.jl
@@ -127,10 +127,24 @@ function test_left_environment(∑h::InfiniteITensorSum, ψ::InfiniteCanonicalMP
     hᴿ[n] -= eᴿ[n] * denseblocks(δ(inds(hᴿ[n])))
   end
 
-  Hᴸ_rec = ITensorInfiniteMPS.left_environment_recursive(hᴸ, ψ; niter=niter)
   Hᴸ = ITensorInfiniteMPS.left_environment(hᴸ, ψ)
+  Hᴸ_rec = ITensorInfiniteMPS.left_environment_recursive(hᴸ, ψ; niter=niter)
+
+  @show norm(ITensorInfiniteMPS.Bᴸ(hᴸ, ψ, Nsites)(Hᴸ[Nsites]) - hᴸ[Nsites])
+  @show norm(ITensorInfiniteMPS.Bᴸ(hᴸ, ψ, Nsites)(Hᴸ_rec[Nsites]) - hᴸ[Nsites])
+
+  @show tr(Hᴸ[Nsites] * ψ.C[Nsites] * ψ′.C[Nsites])
+  @show tr(Hᴸ_rec[Nsites] * ψ.C[Nsites] * ψ′.C[Nsites])
+
+  @show Hᴸ[Nsites]
+  @show Hᴸ_rec[Nsites]
+  @show (Hᴸ[Nsites] - Hᴸ_rec[Nsites]) 
+
   return Hᴸ, Hᴸ_rec
 end
 
 Hᴸ, Hᴸ_rec = test_left_environment(H, ψ; niter=40)
+
+nothing
+
 

--- a/examples/vumps/vumps_ising.jl
+++ b/examples/vumps/vumps_ising.jl
@@ -4,7 +4,7 @@ using ITensorInfiniteMPS.ITensors
 N = 2
 
 model = Model"ising"()
-model_kwargs = (J=1.0, h=1.0)
+model_kwargs = (J=1.0, h=0.95)
 
 function space_shifted(::Model"ising", q̃sz)
   return [QN("SzParity", 1 - q̃sz, 2) => 1, QN("SzParity", 0 - q̃sz, 2) => 1]
@@ -22,21 +22,20 @@ H = InfiniteITensorSum(model, s; model_kwargs...)
 @show norm(contract(ψ.AL[1:N]..., ψ.C[N]) - contract(ψ.C[0], ψ.AR[1:N]...))
 
 cutoff = 1e-8
-maxdim = 100
-environment_iterations = 30
-niter = 30
+maxdim = 10
+environment_iterations = 20
+niter = 20
+outer_iters = 4
 vumps_kwargs = (environment_iterations=environment_iterations, niter=niter)
+subspace_expansion_kwargs = (cutoff=cutoff, maxdim=maxdim)
 
 # Alternate steps of running VUMPS and increasing the bond dimension
-ψ = vumps(H, ψ; vumps_kwargs...)
-ψ = subspace_expansion(ψ, H; cutoff=cutoff, maxdim=maxdim)
-ψ = vumps(H, ψ; vumps_kwargs...)
-ψ = subspace_expansion(ψ, H; cutoff=cutoff, maxdim=maxdim)
-ψ = vumps(H, ψ; vumps_kwargs...)
-ψ = subspace_expansion(ψ, H; cutoff=cutoff, maxdim=maxdim)
-ψ = vumps(H, ψ; vumps_kwargs...)
-ψ = subspace_expansion(ψ, H; cutoff=cutoff, maxdim=maxdim)
-ψ = vumps(H, ψ; vumps_kwargs...)
+for _ in 1:outer_iters
+  println("\nIncrease bond dimension")
+  global ψ = subspace_expansion(ψ, H; subspace_expansion_kwargs...)
+  println("Run VUMPS with new bond dimension")
+  global ψ = vumps(H, ψ; vumps_kwargs...)
+end
 
 # Check translational invariance
 @show norm(contract(ψ.AL[1:N]..., ψ.C[N]) - contract(ψ.C[0], ψ.AR[1:N]...))
@@ -45,12 +44,12 @@ vumps_kwargs = (environment_iterations=environment_iterations, niter=niter)
 # Compare to DMRG
 #
 
-Nfinite = 40
+Nfinite = 50
 sfinite = siteinds("S=1/2", Nfinite; conserve_szparity=true)
 Hfinite = MPO(model, sfinite; model_kwargs...)
 ψfinite = randomMPS(sfinite, initstate)
 @show flux(ψfinite)
-sweeps = Sweeps(10)
+sweeps = Sweeps(15)
 setmaxdim!(sweeps, 10)
 setcutoff!(sweeps, 1E-10)
 energy_finite_total, ψfinite = dmrg(Hfinite, ψfinite, sweeps)
@@ -81,93 +80,4 @@ Sz2_infinite = expect(ψ.AL[2] * ψ.C[2], "Sz")
 
 @show Sz1_finite, Sz2_finite
 @show Sz1_infinite, Sz2_infinite
-
-###################################################################
-# Test using linsolve to compute environment
-
-function test_left_environment(∑h::InfiniteITensorSum, ψ::InfiniteCanonicalMPS; niter)
-  Nsites = nsites(ψ)
-  ψᴴ = dag(ψ)
-  ψ′ = ψᴴ'
-  # XXX: make this prime the center sites
-  ψ̃ = prime(linkinds, ψᴴ)
-
-  l = CelledVector([commoninds(ψ.AL[n], ψ.AL[n + 1]) for n in 1:Nsites])
-  l′ = CelledVector([commoninds(ψ′.AL[n], ψ′.AL[n + 1]) for n in 1:Nsites])
-  r = CelledVector([commoninds(ψ.AR[n], ψ.AR[n + 1]) for n in 1:Nsites])
-  r′ = CelledVector([commoninds(ψ′.AR[n], ψ′.AR[n + 1]) for n in 1:Nsites])
-
-  hᴸ = InfiniteMPS([
-    δ(only(l[n - 2]), only(l′[n - 2])) *
-    ψ.AL[n - 1] *
-    ψ.AL[n] *
-    ∑h[(n - 1, n)] *
-    ψ′.AL[n - 1] *
-    ψ′.AL[n] for n in 1:Nsites
-  ])
-
-  hᴿ = InfiniteMPS([
-    δ(only(dag(r[n + 2])), only(dag(r′[n + 2]))) *
-    ψ.AR[n + 2] *
-    ψ.AR[n + 1] *
-    ∑h[(n + 1, n + 2)] *
-    ψ′.AR[n + 2] *
-    ψ′.AR[n + 1] for n in 1:Nsites
-  ])
-
-  eᴸ = [
-    (hᴸ[n] * ψ.C[n] * δ(only(dag(r[n])), only(dag(r′[n]))) * ψ′.C[n])[] for n in 1:Nsites
-  ]
-  eᴿ = [(hᴿ[n] * ψ.C[n] * δ(only(l[n]), only(l′[n])) * ψ′.C[n])[] for n in 1:Nsites]
-
-  for n in 1:Nsites
-    # TODO: use these instead, for now can't subtract
-    # BlockSparse and DiagBlockSparse tensors
-    #hᴸ[n] -= eᴸ[n] * δ(inds(hᴸ[n]))
-    #hᴿ[n] -= eᴿ[n] * δ(inds(hᴿ[n]))
-    hᴸ[n] -= eᴸ[n] * denseblocks(δ(inds(hᴸ[n])))
-    hᴿ[n] -= eᴿ[n] * denseblocks(δ(inds(hᴿ[n])))
-  end
-
-  ## # Compute endcaps as the sum of terms in the unit cell
-  ## hᴸᴺ¹ = hᴸ[Nsites]
-  ## hᴸᴺ¹ = translatecell(hᴸᴺ¹, -1)
-  ## for n in 1:Nsites
-  ##   hᴸᴺ¹ = hᴸᴺ¹ * ψ.AL[n] * ψ̃.AL[n]
-  ## end
-  ## # Loop over the Hamiltonian terms in the unit cell
-  ## for n in 1:Nsites
-  ##   hᴸⁿ = hᴸ[n]
-  ##   for k in (n + 1):Nsites
-  ##     hᴸⁿ = hᴸⁿ * ψ.AL[k] * ψ̃.AL[k]
-  ##   end
-  ##   hᴸᴺ¹ += hᴸⁿ
-  ## end
-  ## hᴸ[Nsites] = hᴸᴺ¹
-
-  @show hᴸ[1]
-  @show hᴸ[2]
-
-  Hᴸ_rec = ITensorInfiniteMPS.left_environment_recursive(hᴸ, ψ; niter=niter)
-
-  hᴸ[2] = hᴸ[1] * ψ.AL[2] * ψ̃.AL[2] + hᴸ[2]
-  Hᴸ = ITensorInfiniteMPS.left_environment(hᴸ, ψ)
-
-  @show norm(ITensorInfiniteMPS.Bᴸ(hᴸ, ψ, Nsites)(Hᴸ[Nsites]) - hᴸ[Nsites])
-  @show norm(ITensorInfiniteMPS.Bᴸ(hᴸ, ψ, Nsites)(Hᴸ_rec[Nsites]) - hᴸ[Nsites])
-
-  @show tr(Hᴸ[Nsites] * ψ.C[Nsites] * ψ′.C[Nsites])
-  @show tr(Hᴸ_rec[Nsites] * ψ.C[Nsites] * ψ′.C[Nsites])
-
-  @show Hᴸ[Nsites]
-  @show Hᴸ_rec[Nsites]
-  @show (Hᴸ[Nsites] - Hᴸ_rec[Nsites]) 
-
-  return Hᴸ, Hᴸ_rec
-end
-
-#Hᴸ, Hᴸ_rec = test_left_environment(H, ψ; niter=40)
-
-nothing
-
 

--- a/src/models.jl
+++ b/src/models.jl
@@ -102,3 +102,16 @@ function ITensors.OpSum(::Model{:heisenberg}, n1, n2)
   opsum += "Sz", n1, "Sz", n2
   return opsum
 end
+
+# H = Σⱼ (½ S⁺ⱼS⁻ⱼ₊₁ + ½ S⁻ⱼS⁺ⱼ₊₁ + SᶻⱼSᶻⱼ₊₁)
+function ITensors.MPO(::Model{:heisenberg}, s)
+  N = length(s)
+  os = OpSum()
+  for j in 1:(N - 1)
+    os .+= 0.5, "S+", j, "S-", j + 1
+    os .+= 0.5, "S-", j, "S+", j + 1
+    os .+= "Sz", j, "Sz", j + 1
+  end
+  return MPO(os, s)
+end
+

--- a/src/models.jl
+++ b/src/models.jl
@@ -114,4 +114,3 @@ function ITensors.MPO(::Model{:heisenberg}, s)
   end
   return MPO(os, s)
 end
-

--- a/src/subspace_expansion.jl
+++ b/src/subspace_expansion.jl
@@ -3,7 +3,7 @@ function replaceind_indval(IV::Tuple, iĩ::Pair)
   return ntuple(n -> first(IV[n]) == i ? ĩ => last(IV[n]) : IV[n], length(IV))
 end
 
-function subspace_expansion(ψ::InfiniteCanonicalMPS, H, b::Tuple{Int,Int}; maxdim, kwargs...)
+function subspace_expansion(ψ::InfiniteCanonicalMPS, H, b::Tuple{Int,Int}; maxdim, cutoff, kwargs...)
   n1, n2 = b
   lⁿ¹ = commoninds(ψ.AL[n1], ψ.C[n1])
   rⁿ¹ = commoninds(ψ.AR[n2], ψ.C[n1])
@@ -27,7 +27,8 @@ function subspace_expansion(ψ::InfiniteCanonicalMPS, H, b::Tuple{Int,Int}; maxd
   ψH2 = noprime(ψ.AL[n1] * H[(n1, n2)] * ψ.C[n1] * ψ.AR[n2])
   ψHN2 = ψH2 * NL * NR
 
-  U, S, V = svd(ψHN2, nL; maxdim=maxdim, kwargs...)
+  U, S, V = svd(ψHN2, nL; maxdim=maxdim, cutoff=cutoff, kwargs...)
+  @show S[end, end]
   NL *= dag(U)
   NR *= dag(V)
 
@@ -108,3 +109,4 @@ function subspace_expansion(ψ, H; kwargs...)
   end
   return ψ
 end
+

--- a/src/subspace_expansion.jl
+++ b/src/subspace_expansion.jl
@@ -3,7 +3,9 @@ function replaceind_indval(IV::Tuple, iĩ::Pair)
   return ntuple(n -> first(IV[n]) == i ? ĩ => last(IV[n]) : IV[n], length(IV))
 end
 
-function subspace_expansion(ψ::InfiniteCanonicalMPS, H, b::Tuple{Int,Int}; maxdim, cutoff, kwargs...)
+function subspace_expansion(
+  ψ::InfiniteCanonicalMPS, H, b::Tuple{Int,Int}; maxdim, cutoff, kwargs...
+)
   n1, n2 = b
   lⁿ¹ = commoninds(ψ.AL[n1], ψ.C[n1])
   rⁿ¹ = commoninds(ψ.AR[n2], ψ.C[n1])
@@ -12,7 +14,9 @@ function subspace_expansion(ψ::InfiniteCanonicalMPS, H, b::Tuple{Int,Int}; maxd
   dʳ = dim(rⁿ¹)
   @assert dˡ == dʳ
   if dˡ ≥ maxdim
-    println("Current bond dimension at bond $b is $dˡ while desired maximum dimension is $maxdim, skipping bond dimension increase")
+    println(
+      "Current bond dimension at bond $b is $dˡ while desired maximum dimension is $maxdim, skipping bond dimension increase",
+    )
     return (ψ.AL[n1], ψ.AL[n2]), ψ.C[n1], (ψ.AR[n1], ψ.AR[n2])
   end
   maxdim -= dˡ
@@ -109,4 +113,3 @@ function subspace_expansion(ψ, H; kwargs...)
   end
   return ψ
 end
-

--- a/src/vumps_localham.jl
+++ b/src/vumps_localham.jl
@@ -188,7 +188,9 @@ function vumps_iteration(args...; multisite_update_alg="sequential", kwargs...)
   elseif multisite_update_alg == "parallel"
     return vumps_iteration_parallel(args...; kwargs...)
   else
-    error("Multisite update algorithm multisite_update_alg = $multisite_update_alg not supported, use \"parallel\" or \"sequential\"")
+    error(
+      "Multisite update algorithm multisite_update_alg = $multisite_update_alg not supported, use \"parallel\" or \"sequential\"",
+    )
   end
 end
 
@@ -196,7 +198,7 @@ function vumps_iteration_sequential(
   ∑h::InfiniteITensorSum,
   ψ::InfiniteCanonicalMPS;
   (ϵᴸ!)=fill(1e-15, nsites(ψ)),
-  (ϵᴿ!)=fill(1e-15, nsites(ψ))
+  (ϵᴿ!)=fill(1e-15, nsites(ψ)),
 )
   Nsites = nsites(ψ)
   ϵᵖʳᵉˢ = max(maximum(ϵᴸ!), maximum(ϵᴿ!))
@@ -254,8 +256,12 @@ function vumps_iteration_sequential(
     end
     Hᴿ = right_environment(hᴿ, ψ; tol=krylov_tol)
 
-    Cvalsₙ₋₁, Cvecsₙ₋₁, Cinfoₙ₋₁ = eigsolve(Hᶜ(∑h, Hᴸ, Hᴿ, ψ, n - 1), ψ.C[n - 1], 1, :SR; ishermitian=true, tol=krylov_tol)
-    Cvalsₙ, Cvecsₙ, Cinfoₙ = eigsolve(Hᶜ(∑h, Hᴸ, Hᴿ, ψ, n), ψ.C[n], 1, :SR; ishermitian=true, tol=krylov_tol)
+    Cvalsₙ₋₁, Cvecsₙ₋₁, Cinfoₙ₋₁ = eigsolve(
+      Hᶜ(∑h, Hᴸ, Hᴿ, ψ, n - 1), ψ.C[n - 1], 1, :SR; ishermitian=true, tol=krylov_tol
+    )
+    Cvalsₙ, Cvecsₙ, Cinfoₙ = eigsolve(
+      Hᶜ(∑h, Hᴸ, Hᴿ, ψ, n), ψ.C[n], 1, :SR; ishermitian=true, tol=krylov_tol
+    )
     Avalsₙ, Avecsₙ, Ainfoₙ = eigsolve(
       Hᴬᶜ(∑h, Hᴸ, Hᴿ, ψ, n), ψ.AL[n] * ψ.C[n], 1, :SR; ishermitian=true, tol=krylov_tol
     )
@@ -359,7 +365,9 @@ function vumps_iteration_parallel(
   C̃ = InfiniteMPS(Vector{ITensor}(undef, Nsites))
   Ãᶜ = InfiniteMPS(Vector{ITensor}(undef, Nsites))
   for n in 1:Nsites
-    Cvalsₙ, Cvecsₙ, Cinfoₙ = eigsolve(Hᶜ(∑h, Hᴸ, Hᴿ, ψ, n), ψ.C[n], 1, :SR; ishermitian=true, tol=krylov_tol)
+    Cvalsₙ, Cvecsₙ, Cinfoₙ = eigsolve(
+      Hᶜ(∑h, Hᴸ, Hᴿ, ψ, n), ψ.C[n], 1, :SR; ishermitian=true, tol=krylov_tol
+    )
     Avalsₙ, Avecsₙ, Ainfoₙ = eigsolve(
       Hᴬᶜ(∑h, Hᴸ, Hᴿ, ψ, n), ψ.AL[n] * ψ.C[n], 1, :SR; ishermitian=true, tol=krylov_tol
     )
@@ -387,21 +395,27 @@ function vumps_iteration_parallel(
   return InfiniteCanonicalMPS(Ãᴸ, C̃, Ãᴿ), (eᴸ, eᴿ)
 end
 
-function vumps(∑h, ψ; maxiter=10, tol=1e-8, outputlevel=1, multisite_update_alg="sequential")
+function vumps(
+  ∑h, ψ; maxiter=10, tol=1e-8, outputlevel=1, multisite_update_alg="sequential"
+)
   N = nsites(ψ)
-  (ϵᴸ!)=fill(tol, nsites(ψ))
-  (ϵᴿ!)=fill(tol, nsites(ψ))
-  outputlevel > 0 && println("Running VUMPS with multisite_update_alg = $multisite_update_alg")
+  (ϵᴸ!) = fill(tol, nsites(ψ))
+  (ϵᴿ!) = fill(tol, nsites(ψ))
+  outputlevel > 0 &&
+    println("Running VUMPS with multisite_update_alg = $multisite_update_alg")
   for iter in 1:maxiter
-    ψ, (eᴸ, eᴿ) = vumps_iteration(∑h, ψ; (ϵᴸ!)=(ϵᴸ!), (ϵᴿ!)=(ϵᴿ!), multisite_update_alg=multisite_update_alg)
+    ψ, (eᴸ, eᴿ) = vumps_iteration(
+      ∑h, ψ; (ϵᴸ!)=(ϵᴸ!), (ϵᴿ!)=(ϵᴿ!), multisite_update_alg=multisite_update_alg
+    )
     ϵᵖʳᵉˢ = max(maximum(ϵᴸ!), maximum(ϵᴿ!))
     maxdimψ = maxlinkdim(ψ[0:(N + 1)])
-    outputlevel > 0 &&
-      println(
-              "VUMPS iteration $iter (out of maximum $maxiter). Bond dimension = $maxdimψ, energy = $((eᴸ, eᴿ)), ϵᵖʳᵉˢ = $ϵᵖʳᵉˢ, tol = $tol"
-      )
+    outputlevel > 0 && println(
+      "VUMPS iteration $iter (out of maximum $maxiter). Bond dimension = $maxdimψ, energy = $((eᴸ, eᴿ)), ϵᵖʳᵉˢ = $ϵᵖʳᵉˢ, tol = $tol",
+    )
     if ϵᵖʳᵉˢ < tol
-      println("Precision error $ϵᵖʳᵉˢ reached tolerance $tol, stopping VUMPS after $iter iterations (of a maximum $maxiter).")
+      println(
+        "Precision error $ϵᵖʳᵉˢ reached tolerance $tol, stopping VUMPS after $iter iterations (of a maximum $maxiter).",
+      )
       break
     end
   end

--- a/src/vumps_localham.jl
+++ b/src/vumps_localham.jl
@@ -401,7 +401,7 @@ function vumps(∑h, ψ; maxiter=10, tol=1e-8, outputlevel=1, multisite_update_a
               "VUMPS iteration $iter (out of maximum $maxiter). Bond dimension = $maxdimψ, energy = $((eᴸ, eᴿ)), ϵᵖʳᵉˢ = $ϵᵖʳᵉˢ, tol = $tol"
       )
     if ϵᵖʳᵉˢ < tol
-      println("Precision error $ϵᵖʳᵉˢ reached tolerance $tol, stopping VUMPS iterations.")
+      println("Precision error $ϵᵖʳᵉˢ reached tolerance $tol, stopping VUMPS after $iter iterations (of a maximum $maxiter).")
       break
     end
   end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,20 +27,21 @@ using Random
 
   cutoff = 1e-8
   maxdim = 100
-  environment_iterations = 20
-  niter = 20
+  tol = 1e-8
+  maxiter = 20
   outer_iters = 3
-  vumps_kwargs = (environment_iterations=environment_iterations, niter=niter, outputlevel=0)
+  vumps_kwargs = (tol=tol, maxiter=maxiter, outputlevel=0)
+  subspace_expansion_kwargs = (cutoff=cutoff, maxdim=maxdim)
 
   # Alternate steps of running VUMPS and increasing the bond dimension
   ψ = vumps(H, ψ; vumps_kwargs...)
   for _ in 1:outer_iters
-    ψ = subspace_expansion(ψ, H; cutoff=cutoff, maxdim=maxdim)
+    ψ = subspace_expansion(ψ, H; subspace_expansion_kwargs...)
     ψ = vumps(H, ψ; vumps_kwargs...)
   end
 
   # Check translational invariance
-  @test contract(ψ.AL[1:N]..., ψ.C[N]) ≈ contract(ψ.C[0], ψ.AR[1:N]...) rtol = 1e-7
+  @test contract(ψ.AL[1:N]..., ψ.C[N]) ≈ contract(ψ.C[0], ψ.AR[1:N]...) rtol = 1e-6
 
   #
   # Compare to DMRG


### PR DESCRIPTION
Various convergence and interface improvements to VUMPS:

1. Use Krylov linear solver to accelerate environment update.
2. Automatically tune the linear solver and eigensolver tolerance based on the precision error.
3. Use the precision error as a stopping criteria based on an input tolerance.
4. Use a sequential update instead of a parallel update by default (parallel update is available with a keyword argument), which seems to converge better in general.

Also simplify the VUMPS examples a bit.